### PR TITLE
Add a live preview for markdown files

### DIFF
--- a/vim/options/cheatsheet.vim
+++ b/vim/options/cheatsheet.vim
@@ -1,0 +1,3 @@
+" This command vertically splits a vim session with a cheatsheet
+command Chtsht :vsp ~/.vim-cheatsheet.md
+

--- a/vim/rcplugins/vim-livedown.vim
+++ b/vim/rcplugins/vim-livedown.vim
@@ -1,0 +1,2 @@
+" Used to toggle Markdown live preview
+nmap gm :LivedownToggle<CR>

--- a/vim/vundle/vundle.vim
+++ b/vim/vundle/vundle.vim
@@ -21,6 +21,7 @@ Plugin 'tpope/vim-rails'
 " ===== Syntax =====
 Plugin 'gabrielelana/vim-markdown'
 Plugin 'ntpeters/vim-better-whitespace'
+Plugin 'shime/vim-livedown'
 
 " ====== Powerline, Statusline, etc. ======
 Plugin 'itchyny/lightline.vim'


### PR DESCRIPTION
Uses `shime/vim-livedown` to enable a Github-flavoured live preview of markdown files.